### PR TITLE
exposes the deepl error to the developer.

### DIFF
--- a/src/functions/translate.ts
+++ b/src/functions/translate.ts
@@ -13,7 +13,7 @@ import { UsageResponse } from '../interfaces/usage/usageResponse';
 export async function translate(params: TranslationParameters): Promise<TranslationResponse> {
   const response = await fetch(`https://api.deepl.com/v2/translate?${querystring.stringify(params)}`);
 
-  if (!response.ok) throw 'Something went wrong. Are you using a valid authorization key?';
+  if (!response.ok) throw `Something went wrong. Are you using a valid authorization key? (${await response.json()})`;
 
   return response.json();
 }
@@ -26,7 +26,7 @@ export async function translate(params: TranslationParameters): Promise<Translat
 export async function usage(params: UsageParameters): Promise<UsageResponse> {
   const response = await fetch(`https://api.deepl.com/v2/usage?${querystring.stringify(params)}`);
 
-  if (!response.ok) throw 'Something went wrong. Are you using a valid authorization key?';
+  if (!response.ok) throw 'Something went wrong. Are you using a valid authorization key? (${await response.json()})';
 
   return response.json();
 }

--- a/src/functions/translate.ts
+++ b/src/functions/translate.ts
@@ -26,7 +26,7 @@ export async function translate(params: TranslationParameters): Promise<Translat
 export async function usage(params: UsageParameters): Promise<UsageResponse> {
   const response = await fetch(`https://api.deepl.com/v2/usage?${querystring.stringify(params)}`);
 
-  if (!response.ok) throw 'Something went wrong. Are you using a valid authorization key? (${await response.json()})';
+  if (!response.ok) throw `Something went wrong. Are you using a valid authorization key? (${await response.json()})`;
 
   return response.json();
 }


### PR DESCRIPTION
I was getting errors when translating to english. just got the "something went wrong..." message.
What actually happened was that i provided the formality option to an unsupported language (EN in this case).
I did not intially check that this will not work and the error didnt give me any hints.